### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -13,7 +13,7 @@ handle_command	KEYWORD2
 is_connected	KEYWORD2
 read_packet	KEYWORD2
 
-send_sensor_samples KEYWORD2
+send_sensor_samples	KEYWORD2
 
 debug_flash_led	KEYWORD2
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords